### PR TITLE
Clarify CORS behavior for report uploads

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -774,43 +774,53 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
           directly. Depending on load, the user agent MAY instead wait for
           [[#gc]] at some point in the future.
 
-  4.  For each (|endpoint|, |reports|) pair in |endpoint map|, execute the
-      following steps asynchronously:
+  4.  For each (|endpoint|, |reports|) pair in |endpoint map|:
 
-      1.  Let |result| be the result of executing [[#try-delivery]] on
-          |endpoint| and |reports|.
+      1.  Let |origin map| be an empty map of <a spec="html">origins</a> to
+          lists of <a>report</a> objects.
 
-      2.  If |result| is "`Success`":
+      2.  For each |report| in |reports|:
 
-          1.  Set |endpoint|'s {{endpoint/failures}} to 0, and its
-              {{endpoint/retry_after}} to `null`.
+          1.  Append |report| to |origin map|'s list of reports for |report|'s
+              [=report/origin=].
 
-          2.  Remove each <a>report</a> in |reports| from the <a>reporting
-              cache</a>.
+      3.  For each (|origin|, |per-origin reports|) pair in |origin map|,
+          execute the following steps asynchronously:
 
-          Otherwise, if |result| is "`Remove Endpoint`":
+          1.  Let |result| be the result of executing [[#try-delivery]] on
+              |endpoint|, |origin|, and |per-origin reports|.
 
-          1.  Remove |endpoint| from the reporting cache.
+          2.  If |result| is "`Success`":
 
-              Note: |reports| remain in the reporting cache for potential
-              delivery to other endpoints.
+              1.  Set |endpoint|'s {{endpoint/failures}} to 0, and its
+                  {{endpoint/retry_after}} to `null`.
 
-          Otherwise (if |result| is "`Failure`"):
+              2.  Remove each <a>report</a> in |reports| from the <a>reporting
+                  cache</a>.
 
-          1.  Increment |endpoint|'s {{endpoint/failures}}.
+              Otherwise, if |result| is "`Remove Endpoint`":
 
-          2.  Set |endpoint|'s {{endpoint/retry_after}} to a point in the future
-              which the user agent chooses.
+              1.  Remove |endpoint| from the reporting cache.
 
-              Note: We don't specify a particular algorithm here, but user
-              agents are encouraged to employ some sort of exponential backoff
-              algorithm which increases the retry period with the number of
-              failures, with the addition of some random jitter to ensure that
-              temporary failures don't lead to a crush of reports all being
-              retried on the same schedule.
+                  Note: |reports| remain in the reporting cache for potential
+                  delivery to other endpoints.
 
-              ISSUE: Add in a reasonable reference describing a good algorithm.
-              Wikipedia, if nothing else.
+              Otherwise (if |result| is "`Failure`"):
+
+              1.  Increment |endpoint|'s {{endpoint/failures}}.
+
+              2.  Set |endpoint|'s {{endpoint/retry_after}} to a point in the
+                  future which the user agent chooses.
+
+                  Note: We don't specify a particular algorithm here, but user
+                  agents are encouraged to employ some sort of exponential
+                  backoff algorithm which increases the retry period with the
+                  number of failures, with the addition of some random jitter to
+                  ensure that temporary failures don't lead to a crush of
+                  reports all being retried on the same schedule.
+
+                  ISSUE: Add in a reasonable reference describing a good
+                  algorithm.  Wikipedia, if nothing else.
 
   Note: User agents MAY decide to attempt delivery for only a subset of the
   collected reports or endpoints (because, for example, sending all the reports
@@ -822,11 +832,12 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     Attempt to deliver |reports| to |endpoint|
   </h3>
 
-  Given a list of <a>reports</a> (|reports|) and an <a>endpoint</a>
-  (|endpoint|), this algorithm will construct a <a>request</a>, and attempt to
-  deliver it to |endpoint|. It returns "`Success`" if that delivery succeeds,
-  "`Remove Endpoint`" if the endpoint explicitly removes itself as a reporting
-  endpoint by sending a 410 response, and "`Failure`" otherwise.
+  Given an <a>endpoint</a> (|endpoint|), an <a spec="html">origin</a>
+  (|origin|), and a list of <a>reports</a> (|reports|), this algorithm will
+  construct a <a>request</a>, and attempt to deliver it to |endpoint|. It
+  returns "`Success`" if that delivery succeeds, "`Remove Endpoint`" if the
+  endpoint explicitly removes itself as a reporting endpoint by sending a 410
+  response, and "`Failure`" otherwise.
 
   1.  Let |collection| be a new ECMAScript `Array` object [[!ECMA-262]].
 
@@ -858,6 +869,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
 
       :   `url`
       ::  |endpoint|'s {{endpoint/url}}
+      :   `origin`
+      ::  |origin|
       :   `header list`
       ::  A new <a>header list</a> containing a <a>header</a> named
           "`Content-Type`" whose value is "`application/report`"
@@ -869,19 +882,19 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       ::  Set.
       :   `initiator`
       ::  ""
-      :   `type`
+      :   `destination`
       ::  "`report`"
       :   `destination`
       ::  ""
       :   `mode`
       ::  "`cors`"
+      :   `unsafe-request` flag
+      ::  set
       :   `credentials`
       ::  "`include`"
       :   `body`
       ::  The string resulting from executing the {{JSON.stringify()}} algorithm
           on |collection| [[!ECMA-262]]
-
-      ISSUE: The "`report`" type does not exist in Fetch. Talk to Anne.
 
   4.  <a>Queue a task</a> to <a>fetch</a> |request|.
 


### PR DESCRIPTION
Report uploads are supposed to behave The Right Way and send CORS preflight requests.  We have to set Fetch's `unsafe-request` flag to trigger the preflights, and we also need to have a reasonable `Origin`.  We use the origin of the reports themselves.  This means that any particular report upload can only contain reports about a single origin, so this patch also adds an extra step to the upload algorithm to sort reports by origin after endpoints have been chosen.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/97.html" title="Last updated on Jul 9, 2018, 12:54 PM GMT (d3eb00f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/97/b52e0a2...dcreager:d3eb00f.html" title="Last updated on Jul 9, 2018, 12:54 PM GMT (d3eb00f)">Diff</a>