### PR TITLE
Clarify name of "observability" property

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -309,10 +309,10 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   that is contained in the [=report/body=] of a <a>report</a>.
 
   When a <a>report type</a> is defined (in this spec or others), it can be
-  specified to be <dfn>observable from JavaScript</dfn>, meaning
+  specified to be <dfn>visible to <code>ReportingObservers</code></dfn>, meaning
   that <a>reports</a> of that type can be observed by a <a>reporting
-  observer</a>. By default, <a>report types</a> are not <a>observable from
-  JavaScript</a>.
+    observer</a>. By default, <a>report types</a> are not <a>visible to
+    <code>ReportingObserver</code>s</a>.
 
   Note: See [[#deprecation-report]] as an example <a>report type</a> definition.
 
@@ -1066,8 +1066,8 @@ typedef sequence&lt;Report> ReportList;
   algorithm adds |report| to |observer|'s <a>report list</a>, so long as
   |report|'s <a>type</a> is observable by |observer|.
 
-  1. If |report|'s [=report/type=] is not <a>observable from JavaScript</a>,
-     return.
+  1. If |report|'s [=report/type=] is not <a>visible to
+    <code>ReportingObserver</code>s</a>, return.
 
   2. If |observer|'s <a>options</a> has a non-empty
      {{ReportingObserverOptions/types}} member which does not contain |report|'s
@@ -1117,7 +1117,8 @@ typedef sequence&lt;Report> ReportList;
 
   <a>Deprecation reports</a> have the <a>report type</a> "deprecation".
 
-  <a>Deprecation reports</a> are <a>observable from JavaScript</a>.
+  <a>Deprecation reports</a> are <a>visible to
+  <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
     interface DeprecationReportBody : ReportBody {
@@ -1172,7 +1173,8 @@ typedef sequence&lt;Report> ReportList;
 
   <a>Intervention reports</a> have the <a>report type</a> "intervention".
 
-  <a>Intervention reports</a> are <a>observable from JavaScript</a>.
+  <a>Intervention reports</a> are <a>visible to
+  <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
     interface InterventionReportBody : ReportBody {

--- a/index.src.html
+++ b/index.src.html
@@ -309,7 +309,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   that is contained in the [=report/body=] of a <a>report</a>.
 
   When a <a>report type</a> is defined (in this spec or others), it can be
-  specified to be <dfn>visible to <code>ReportingObservers</code></dfn>, meaning
+  specified to be <dfn>visible to <code>ReportingObserver</code>s</dfn>, meaning
   that <a>reports</a> of that type can be observed by a <a>reporting
     observer</a>. By default, <a>report types</a> are not <a>visible to
     <code>ReportingObserver</code>s</a>.


### PR DESCRIPTION
In w3c/network-error-logging#77 there was some confusion about what "observable from JavaScript" means.  The intended meaning is very specific: the report will not be handed off to any registered `ReportingObserver`s.  Another reading that is you can perform whatever complicated analysis you want, and somehow detect that a report was created.  This patch renames the term to something that hopefully can only be read in the more specific way.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/101.html" title="Last updated on Jul 9, 2018, 12:48 PM GMT (3e30a10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/101/e11ec2a...dcreager:3e30a10.html" title="Last updated on Jul 9, 2018, 12:48 PM GMT (3e30a10)">Diff</a>