### PR TITLE
Update formatting of field in IDLs

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1149,11 +1149,11 @@ typedef sequence&lt;Report> ReportList;
   <pre class="idl">
     interface DeprecationReportBody : ReportBody {
       readonly attribute DOMString id;
-      readonly attribute Date? anticipatedRemoval;
+      readonly attribute Date? anticipated_removal;
       readonly attribute DOMString message;
-      readonly attribute DOMString? sourceFile;
-      readonly attribute long? lineNumber;
-      readonly attribute long? columnNumber;
+      readonly attribute DOMString? source_file;
+      readonly attribute long? line_number;
+      readonly attribute long? column_number;
     };
   </pre>
 
@@ -1206,9 +1206,9 @@ typedef sequence&lt;Report> ReportList;
     interface InterventionReportBody : ReportBody {
       readonly attribute DOMString id;
       readonly attribute DOMString message;
-      readonly attribute DOMString? sourceFile;
-      readonly attribute long? lineNumber;
-      readonly attribute long? columnNumber;
+      readonly attribute DOMString? source_file;
+      readonly attribute long? line_number;
+      readonly attribute long? column_number;
     };
   </pre>
 
@@ -1216,8 +1216,8 @@ typedef sequence&lt;Report> ReportList;
   {{InterventionReportBody}}, contains the following fields:
 
     - <dfn for="InterventionReportBody">id</dfn>: an implementation-defined
-      string identifying the specific intervention that occurred. This string can
-      be used for grouping and counting related reports.
+      string identifying the specific intervention that occurred. This string
+      can be used for grouping and counting related reports.
 
     - <dfn for="InterventionReportBody">message</dfn>: A human-readable string
       with details typically matching what would be displayed on the developer


### PR DESCRIPTION
I just realized that I missed the definitions in the IDLs for the report types when changing the formatting of fields from camelCase to underscore_separated (see issue #72).

This change updates those IDL fields.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/109.html" title="Last updated on Jul 13, 2018, 7:52 PM GMT (f4e9abe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/109/f02cf36...paulmeyer90:f4e9abe.html" title="Last updated on Jul 13, 2018, 7:52 PM GMT (f4e9abe)">Diff</a>