### PR TITLE
Make ALL formatting consistent.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -45,25 +45,25 @@ Deprecations are reports indicating that a browser API or feature has been used 
   "url": "https://example.com/",
   "body": {
     "id": "websql", 
-    "anticipated_removal": "1/1/2020", 
+    "anticipatedRemoval": "1/1/2020", 
     "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
-    "source_file": "https://foo.com/index.js",
-    "line_number": 1234,
-    "column_number": 42
+    "sourceFile": "https://foo.com/index.js",
+    "lineNumber": 1234,
+    "columnNumber": 42
   }
 }
 ```
 
 The report has the following properties:
 - `id` (required): an implementation-defined string identifying the feature or API that will be removed.  This string can be used for grouping and counting related reports.
-- `anticipated_removal`: A date indicating roughly when the browser version without the specified API will be generally available (excluding "beta" or other pre-release channels).  This value should be used to sort or prioritize warnings.  When omitted the deprecation should be considered low priority (removal may not actually occur).  
+- `anticipatedRemoval`: A date indicating roughly when the browser version without the specified API will be generally available (excluding "beta" or other pre-release channels).  This value should be used to sort or prioritize warnings.  When omitted the deprecation should be considered low priority (removal may not actually occur).  
 - `message`: A developer-readable message with details (typically matching what would be displayed on the developer console).  The message is not guaranteed to be unique for a given `id` (eg. it may contain additional context on how the API was used).
-- `source_file`: If known, the file which first used the indicated API
-- `line_number`: if known, the line number in `source_file` where the indicated API was first used.
-- `column_number`: if known, the column number in `source_file` where the indicated API was first used.
+- `sourceFile`: If known, the file which first used the indicated API
+- `lineNumber`: if known, the line number in `sourceFile` where the indicated API was first used.
+- `columnNumber`: if known, the column number in `sourceFile` where the indicated API was first used.
 
 ### Interventions ###
-An [intervention](https://github.com/WICG/interventions/blob/master/README.md) occurs when a browser decides not to honor a request made by the application (eg. for security, performance or user annoyance reasons).  The report properties are the same as those for deprecations, except for the absense of `anticipated_removal`.
+An [intervention](https://github.com/WICG/interventions/blob/master/README.md) occurs when a browser decides not to honor a request made by the application (eg. for security, performance or user annoyance reasons).  The report properties are the same as those for deprecations, except for the absense of `anticipatedRemoval`.
 
 ```json
 {
@@ -73,9 +73,9 @@ An [intervention](https://github.com/WICG/interventions/blob/master/README.md) o
   "body": {
     "id": "audio-no-gesture", 
     "message": "A request to play audio was blocked because it was not triggered by user activation (such as a click).",
-    "source_file": "https://foo.com/index.js",
-    "line_number": 1234,
-    "column_number": 42
+    "sourceFile": "https://foo.com/index.js",
+    "lineNumber": 1234,
+    "columnNumber": 42
   }
 }
 ```
@@ -89,14 +89,14 @@ A crash report indicates that the user was unable to continue using the page bec
   "age": 10,
   "url": "https://example.com/",
   "body": {
-    "crash_id": "c2dd3217-24f5-4bee-b74d-99bd055e7edb",
+    "crashId": "c2dd3217-24f5-4bee-b74d-99bd055e7edb",
     "type": "oom"
   }
 }
 ```
 
 The report has the following properties:
-- `crash_id`: A unique identifier. This identifier will not be meaningful to developers directly, but it can potentially be supplied to the browser vendor for more details.
+- `crashId`: A unique identifier. This identifier will not be meaningful to developers directly, but it can potentially be supplied to the browser vendor for more details.
 - `type`: A more specific classification of the type of crash that occured. Currently, the only valid type is "oom" (omitted otherwise), indicating an out-of-memory crash.
 
 ## ReportingObserver - Observing reports from JavaScript

--- a/index.src.html
+++ b/index.src.html
@@ -1161,7 +1161,7 @@ typedef sequence&lt;Report> ReportList;
       string identifying the feature or API that will be removed. This string
       can be used for grouping and counting related reports.
 
-    - <dfn for="DeprecationReportBody">anticipated_removal</dfn>: A
+    - <dfn for="DeprecationReportBody">anticipatedRemoval</dfn>: A
       JavaScript <a>Date object</a> (rendered as an ISO 8601 string) indicating
       roughly when the browser version without the specified API will be
       generally available (excluding "beta" or other pre-release channels). This
@@ -1175,15 +1175,15 @@ typedef sequence&lt;Report> ReportList;
       [=DeprecationReportBody/id=] (eg. it may contain additional context on how
       the API was used).
 
-    - <dfn for="DeprecationReportBody">source_file</dfn>: If known, the file
+    - <dfn for="DeprecationReportBody">sourceFile</dfn>: If known, the file
       which first used the indicated API, or null otherwise.
 
-    - <dfn for="DeprecationReportBody">line_number</dfn>: If known, the line
-      number in [=DeprecationReportBody/source_file=] where the indicated API
+    - <dfn for="DeprecationReportBody">lineNumber</dfn>: If known, the line
+      number in [=DeprecationReportBody/sourceFile=] where the indicated API
       was first used, or null otherwise.
 
-    - <dfn for="DeprecationReportBody">column_number</dfn>: If known, the column
-      number in [=DeprecationReportBody/source_file=] where the indicated API
+    - <dfn for="DeprecationReportBody">columnNumber</dfn>: If known, the column
+      number in [=DeprecationReportBody/sourceFile=] where the indicated API
       was first used, or null otherwise.
 
   <h3 id="intervention-report">Intervention</h3>
@@ -1192,7 +1192,7 @@ typedef sequence&lt;Report> ReportList;
   honor a request made by the application (e.g. for security, performance or
   user annoyance reasons). Note that the report properties are the same as those
   for <a>deprecation reports</a>, except for the absence of
-  [=DeprecationReportBody/anticipated_removal=].
+  [=DeprecationReportBody/anticipatedRemoval=].
 
   <a>Intervention reports</a> have the <a>report type</a> "intervention".
 
@@ -1222,15 +1222,15 @@ typedef sequence&lt;Report> ReportList;
       [=InterventionReportBody/id=] (e.g. it may contain additional context on
       what led to the intervention).
 
-    - <dfn for="InterventionReportBody">source_file</dfn>: If known, the file
+    - <dfn for="InterventionReportBody">sourceFile</dfn>: If known, the file
       which first used the indicated API, or null otherwise.
 
-    - <dfn for="InterventionReportBody">line_number</dfn>: If known, the line
-      number in [=InterventionReportBody/source_file=] of the offending behavior
+    - <dfn for="InterventionReportBody">lineNumber</dfn>: If known, the line
+      number in [=InterventionReportBody/sourceFile=] of the offending behavior
       (which prompted the intervention), or null otherwise.
 
-    - <dfn for="InterventionReportBody">column_number</dfn>: If known, the
-      column number in [=InterventionReportBody/source_file=] of the offending
+    - <dfn for="InterventionReportBody">columnNumber</dfn>: If known, the
+      column number in [=InterventionReportBody/sourceFile=] of the offending
       behavior (which prompted the intervention), or null otherwise.
 
 </section>


### PR DESCRIPTION
See #109 for more context.

This change makes all of the formatting more consistent. Previously, we had changed a number of fields from camel case to underscore separated in order to match the TAG format guidelines, but actually, the guidelines still recommend camel case for IDLs and JavaScript fields, so we're going to match that for the IDLs in this spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/111.html" title="Last updated on Jul 18, 2018, 5:40 PM GMT (0623c46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/111/d6f71a0...paulmeyer90:0623c46.html" title="Last updated on Jul 18, 2018, 5:40 PM GMT (0623c46)">Diff</a>