### PR TITLE
Make |lineNumber| and |columnNumber| unsigned.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1149,8 +1149,8 @@ typedef sequence&lt;Report> ReportList;
       readonly attribute Date? anticipatedRemoval;
       readonly attribute DOMString message;
       readonly attribute DOMString? sourceFile;
-      readonly attribute long? lineNumber;
-      readonly attribute long? columnNumber;
+      readonly attribute unsigned long? lineNumber;
+      readonly attribute unsigned long? columnNumber;
     };
   </pre>
 
@@ -1204,8 +1204,8 @@ typedef sequence&lt;Report> ReportList;
       readonly attribute DOMString id;
       readonly attribute DOMString message;
       readonly attribute DOMString? sourceFile;
-      readonly attribute long? lineNumber;
-      readonly attribute long? columnNumber;
+      readonly attribute unsigned long? lineNumber;
+      readonly attribute unsigned long? columnNumber;
     };
   </pre>
 


### PR DESCRIPTION
See issue #105


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/112.html" title="Last updated on Jul 20, 2018, 6:38 PM GMT (58ce308)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/112/80aa7d2...paulmeyer90:58ce308.html" title="Last updated on Jul 20, 2018, 6:38 PM GMT (58ce308)">Diff</a>