### PR TITLE
Define crash reports

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -81,7 +81,7 @@ An [intervention](https://github.com/WICG/interventions/blob/master/README.md) o
 ```
 
 ### Crashes ###
-A crash report indicates that the user was unable to continue using the page because the browser (or one of it's processes necessary for the page) crashed.  For security reasons, no details of the crash are communicated except (optionally) the type of crash (such as "oom") and/or a unique identifier which can be supplied to the browser vendor. 
+A crash report indicates that the user was unable to continue using the page because the browser (or one of its processes necessary for the page) crashed.  For security reasons, no details of the crash are communicated except (optionally) the type of crash (such as "oom") and a unique identifier which can be supplied to the browser vendor. 
 
 ```json
 {
@@ -90,14 +90,14 @@ A crash report indicates that the user was unable to continue using the page bec
   "url": "https://example.com/",
   "body": {
     "crashId": "c2dd3217-24f5-4bee-b74d-99bd055e7edb",
-    "type": "oom"
+    "reason": "oom"
   }
 }
 ```
 
 The report has the following properties:
 - `crashId`: A unique identifier. This identifier will not be meaningful to developers directly, but it can potentially be supplied to the browser vendor for more details.
-- `type`: A more specific classification of the type of crash that occured. Currently, the only valid type is "oom" (omitted otherwise), indicating an out-of-memory crash.
+- `reason`: A more specific classification of the type of crash that occured. Currently, the only valid type is "oom" (omitted otherwise), indicating an out-of-memory crash.
 
 ## ReportingObserver - Observing reports from JavaScript
 In addition to (or even instead of) having reports delivered to an endpoint, it can be convenient to be informed of reports from within the page's JavaScript (eg. for analytics libraries which have no way to influence HTTP headers).  This doesn't make sense or isn't possible for all reports (eg. crashes), but is most useful for reports generated as a direct result of something the page's script has done (such as a deprecation warning).

--- a/index.src.html
+++ b/index.src.html
@@ -1292,14 +1292,30 @@ typedef sequence&lt;Report> ReportList;
   An <a>crash report</a>'s [=report/body=], represented in JavaScript by
   {{CrashReportBody}}, contains the following fields:
 
-    - <dfn for="CrashReportBody">crashId</dfn>: A unique identifier. This
-      identifier will not be meaningful to developers directly, but it can
-      potentially be supplied to the browser vendor for more details.
+    - <dfn for="CrashReportBody">crashId</dfn>: An implementation-defined unique
+      identifier (100 character maximum string). This identifier will not be
+      meaningful to developers directly, but it can potentially be supplied to
+      the browser vendor for more details.
 
     - <dfn for="CrashReportBody">reason</dfn>: A more specific classification of
       the type of crash that occured. Currently, the only valid
       [=CrashReportBody/reason=] is "oom" (omitted otherwise), indicating an
       out-of-memory crash.
+
+  <div class="example">
+  <pre>
+  {
+    "type": "crash",
+    "age": 42,
+    "url": "https://example.com/",
+    "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+    "body": {
+      "crashId": "30437694edfeae5b",
+      "reason": "oom"
+    }
+  }
+  </pre>
+  </div>
 </section>
 
 <section>

--- a/index.src.html
+++ b/index.src.html
@@ -312,8 +312,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   When a <a>report type</a> is defined (in this spec or others), it can be
   specified to be <dfn>visible to <code>ReportingObserver</code>s</dfn>, meaning
   that <a>reports</a> of that type can be observed by a <a>reporting
-    observer</a>. By default, <a>report types</a> are not <a>visible to
-    <code>ReportingObserver</code>s</a>.
+  observer</a>. By default, <a>report types</a> are not <a>visible to
+  <code>ReportingObserver</code>s</a>.
 
   Note: See [[#deprecation-report]] as an example <a>report type</a> definition.
 
@@ -1269,6 +1269,37 @@ typedef sequence&lt;Report> ReportList;
   }
   </pre>
   </div>
+
+  <h3 id="crash-report">Crash</h3>
+
+  <dfn>Crash reports</dfn> indicate that the user was unable to continue using
+  the page because the browser (or one of its processes necessary for the page)
+  crashed. For security reasons, no details of the crash are communicated except
+  for and a unique identifier (which can be interpreted by the browser vendor),
+  and optionally the reason for the crash (such as "oom").
+
+  <a>Crash reports</a> have the <a>report type</a> "crash".
+
+  <a>Crash reports</a> are <a>visible to <code>ReportingObserver</code>s</a>.
+
+  <pre class="idl">
+    interface CrashReportBody : ReportBody {
+      readonly attribute DOMString crashId;
+      readonly attribute DOMString? reason;
+    };
+  </pre>
+
+  An <a>crash report</a>'s [=report/body=], represented in JavaScript by
+  {{CrashReportBody}}, contains the following fields:
+
+    - <dfn for="CrashReportBody">crashId</dfn>: A unique identifier. This
+      identifier will not be meaningful to developers directly, but it can
+      potentially be supplied to the browser vendor for more details.
+
+    - <dfn for="CrashReportBody">reason</dfn>: A more specific classification of
+      the type of crash that occured. Currently, the only valid
+      [=CrashReportBody/reason=] is "oom" (omitted otherwise), indicating an
+      out-of-memory crash.
 </section>
 
 <section>


### PR DESCRIPTION
This change defines the "crash" report type, as shown in the EXPLAINER.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/113.html" title="Last updated on Jul 24, 2018, 6:59 PM GMT (a83f899)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/113/dae1366...paulmeyer90:a83f899.html" title="Last updated on Jul 24, 2018, 6:59 PM GMT (a83f899)">Diff</a>