### PR TITLE
Add examples to report types

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -47,7 +47,7 @@ Deprecations are reports indicating that a browser API or feature has been used 
     "id": "websql", 
     "anticipatedRemoval": "1/1/2020", 
     "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
-    "sourceFile": "https://foo.com/index.js",
+    "sourceFile": "https://example.com/index.js",
     "lineNumber": 1234,
     "columnNumber": 42
   }
@@ -73,7 +73,7 @@ An [intervention](https://github.com/WICG/interventions/blob/master/README.md) o
   "body": {
     "id": "audio-no-gesture", 
     "message": "A request to play audio was blocked because it was not triggered by user activation (such as a click).",
-    "sourceFile": "https://foo.com/index.js",
+    "sourceFile": "https://example.com/index.js",
     "lineNumber": 1234,
     "columnNumber": 42
   }

--- a/index.src.html
+++ b/index.src.html
@@ -1186,6 +1186,25 @@ typedef sequence&lt;Report> ReportList;
       number in [=DeprecationReportBody/sourceFile=] where the indicated API
       was first used, or null otherwise.
 
+  <div class="example">
+  <pre>
+  {
+    "type": "deprecation",
+    "age": 27,
+    "url": "https://example.com/",
+    "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+    "body": {
+      "id": "websql",
+      "anticipatedRemoval": "1/1/2020",
+      "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
+      "sourceFile": "https://foo.com/index.js",
+      "lineNumber": 1234,
+      "columnNumber": 42
+    }
+  }
+  </pre>
+  </div>
+
   <h3 id="intervention-report">Intervention</h3>
 
   <dfn>Intervention reports</dfn> indicate that a user agent has decided not to
@@ -1233,6 +1252,22 @@ typedef sequence&lt;Report> ReportList;
       column number in [=InterventionReportBody/sourceFile=] of the offending
       behavior (which prompted the intervention), or null otherwise.
 
+  <div class="example">
+  <pre>
+  {
+    "type": "intervention",
+    "age": 27,
+    "url": "https://example.com/",
+    "body": {
+      "id": "audio-no-gesture",
+      "message": "A request to play audio was blocked because it was not triggered by user activation (such as a click).",
+      "sourceFile": "https://foo.com/index.js",
+      "lineNumber": 1234,
+      "columnNumber": 42
+    }
+  }
+  </pre>
+  </div>
 </section>
 
 <section>

--- a/index.src.html
+++ b/index.src.html
@@ -1197,7 +1197,7 @@ typedef sequence&lt;Report> ReportList;
       "id": "websql",
       "anticipatedRemoval": "1/1/2020",
       "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
-      "sourceFile": "https://foo.com/index.js",
+      "sourceFile": "https://example.com/index.js",
       "lineNumber": 1234,
       "columnNumber": 42
     }
@@ -1232,8 +1232,8 @@ typedef sequence&lt;Report> ReportList;
   {{InterventionReportBody}}, contains the following fields:
 
     - <dfn for="InterventionReportBody">id</dfn>: an implementation-defined
-      string identifying the specific intervention that occurred. This string can
-      be used for grouping and counting related reports.
+      string identifying the specific intervention that occurred. This string
+      can be used for grouping and counting related reports.
 
     - <dfn for="InterventionReportBody">message</dfn>: A human-readable string
       with details typically matching what would be displayed on the developer
@@ -1261,7 +1261,7 @@ typedef sequence&lt;Report> ReportList;
     "body": {
       "id": "audio-no-gesture",
       "message": "A request to play audio was blocked because it was not triggered by user activation (such as a click).",
-      "sourceFile": "https://foo.com/index.js",
+      "sourceFile": "https://example.com/index.js",
       "lineNumber": 1234,
       "columnNumber": 42
     }


### PR DESCRIPTION
This change adds examples to the report type sections, similar to those in the EXPLAINER.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/114.html" title="Last updated on Jul 24, 2018, 6:33 PM GMT (1a39ceb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/114/80aa7d2...paulmeyer90:1a39ceb.html" title="Last updated on Jul 24, 2018, 6:33 PM GMT (1a39ceb)">Diff</a>