### PR TITLE
Fix typo in crash reports

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1275,8 +1275,8 @@ typedef sequence&lt;Report> ReportList;
   <dfn>Crash reports</dfn> indicate that the user was unable to continue using
   the page because the browser (or one of its processes necessary for the page)
   crashed. For security reasons, no details of the crash are communicated except
-  for and a unique identifier (which can be interpreted by the browser vendor),
-  and optionally the reason for the crash (such as "oom").
+  for a unique identifier (which can be interpreted by the browser vendor), and
+  optionally the reason for the crash (such as "oom").
 
   <a>Crash reports</a> have the <a>report type</a> "crash".
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jpchase/reporting/pull/116.html" title="Last updated on Jul 26, 2018, 2:07 PM GMT (2f848f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/116/5bdc0e0...jpchase:2f848f5.html" title="Last updated on Jul 26, 2018, 2:07 PM GMT (2f848f5)">Diff</a>