### PR TITLE
Clarify note on header value interpretation

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -423,8 +423,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
                 ; See Section 2 of [[HTTP-JFV]], and Section 2 of [[RFC8259]]
   </pre>
 
-  The header's value is interpreted as an array of JSON objects, as described in
-  Section 4 of [[HTTP-JFV]].
+  The header's value is interpreted as a JSON-formatted array of objects
+  without the outer `[` and `]`, as described in Section 4 of [[HTTP-JFV]].
 
   Each object in the array defines an <a>endpoint group</a> to which reports may
   be delivered, and will be parsed as defined in [[#process-header]].


### PR DESCRIPTION
It's not incorrect to say the header's value is interpreted as an array of JSON-formatted objects, but it is confusing, because "array" is being used in the non-technical sense.

This patch aims to clarify this paragraph.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mathiasbynens/reporting/pull/120.html" title="Last updated on Aug 10, 2018, 8:35 AM GMT (e14c455)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/120/5bdc0e0...mathiasbynens:e14c455.html" title="Last updated on Aug 10, 2018, 8:35 AM GMT (e14c455)">Diff</a>