### PR TITLE
Fix example report-to header syntax.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -202,12 +202,6 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     the following header to define two reporting endpoints:
 
     <pre>
-      <a>Report-To</a>: { "<a for="ReportTo">url</a>": "https://example.com/csp-reports",
-                   "<a for="ReportTo">group</a>": "csp-endpoint",
-                   "<a for="ReportTo">max_age</a>": 10886400 },
-                 { "<a for="ReportTo">url</a>": "https://example.com/hpkp-reports",
-                   "<a for="ReportTo">group</a>": "hpkp-endpoint",
-                   "<a for="ReportTo">max_age</a>": 10886400 }
       <a>Report-To</a>: { "<a for="ReportTo">group</a>": "csp-endpoint",
                    "<a for="ReportTo">max_age</a>": 10886400,
                    "<a for="ReportTo">endpoints</a>": [


### PR DESCRIPTION
Fix #121


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ScottHelme/reporting/pull/122.html" title="Last updated on Sep 4, 2018, 10:17 AM GMT (a1f6306)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/122/30b8aa7...ScottHelme:a1f6306.html" title="Last updated on Sep 4, 2018, 10:17 AM GMT (a1f6306)">Diff</a>