### PR TITLE
Use default value for group in Automation section.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1434,7 +1434,7 @@ typedef sequence&lt;Report> ReportList;
   <pre class='idl'>
     dictionary GenerateTestReportParameters {
       required DOMString message;
-      DOMString group;
+      DOMString group = "default";
     };
   </pre>
 
@@ -1461,25 +1461,23 @@ typedef sequence&lt;Report> ReportList;
   2. Let |message| be the result of <a>trying</a> to get |parameters|'s
      {{GenerateTestReportParameters/message}} property.
 
-  3. If |message| is null, return a <a>WebDriver error</a> with <a>WebDriver
-     error code</a> <a>invalid argument</a>.
+  3. If |message| is not present, return a <a>WebDriver error</a>
+     with <a>WebDriver error code</a> <a>invalid argument</a>.
 
   4. Let |group| be the result of <a>trying</a> to get |parameters|'s
      {{GenerateTestReportParameters/group}} property.
 
-  5. If |group| is null, set |group| to "default".
-
-  6. Let |body| be a new object that can be serialized into a <a>JSON text</a>,
+  5. Let |body| be a new object that can be serialized into a <a>JSON text</a>,
      containing a single string field, |body_message|.
 
-  7. Set |body_message| to |message|.
+  6. Set |body_message| to |message|.
 
-  8. Let |settings| be the <a>environment settings object</a> of the
+  7. Let |settings| be the <a>environment settings object</a> of the
      <a>current browsing context</a>'s <a>active document</a>.
 
-  9. Execute [[#queue-report]] with |body|, "test", |group|, and |settings|.
+  8. Execute [[#queue-report]] with |body|, "test", |group|, and |settings|.
 
-  10. Return <a>success</a> with data null.
+  9. Return <a>success</a> with data null.
 </section>
 
 <section>

--- a/index.src.html
+++ b/index.src.html
@@ -1464,8 +1464,8 @@ typedef sequence&lt;Report> ReportList;
   3. If |message| is not present, return a <a>WebDriver error</a>
      with <a>WebDriver error code</a> <a>invalid argument</a>.
 
-  4. Let |group| be the result of <a>trying</a> to get |parameters|'s
-     {{GenerateTestReportParameters/group}} property.
+  4. Let |group| be |parameters|'s {{GenerateTestReportParameters/group}}
+     property.
 
   5. Let |body| be a new object that can be serialized into a <a>JSON text</a>,
      containing a single string field, |body_message|.


### PR DESCRIPTION
It was recently pointed out that the step to set |group| can be accomplished just by setting its default value in the IDL. This pull request does exactly that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/124.html" title="Last updated on Oct 16, 2018, 7:27 PM GMT (9aaf931)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/124/3c5838e...paulmeyer90:9aaf931.html" title="Last updated on Oct 16, 2018, 7:27 PM GMT (9aaf931)">Diff</a>