### PR TITLE
Clarify endpoint group used for predefined types

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1200,6 +1200,12 @@ typedef sequence&lt;Report> ReportList;
   </pre>
   </div>
 
+  Note: Deprecation reports are always delivered to the <a>endpoint group</a>
+  named <code>default</code>; there is currently no way to override this.  If
+  you want to receive other kinds of reports, but not deprecation reports, make
+  sure to use a different name for the endpoint group that you choose for those
+  reports.
+
   <h3 id="intervention-report">Intervention</h3>
 
   <dfn>Intervention reports</dfn> indicate that a user agent has decided not to
@@ -1264,6 +1270,12 @@ typedef sequence&lt;Report> ReportList;
   </pre>
   </div>
 
+  Note: Intervention reports are always delivered to the <a>endpoint group</a>
+  named <code>default</code>; there is currently no way to override this.  If
+  you want to receive other kinds of reports, but not intervention reports, make
+  sure to use a different name for the endpoint group that you choose for those
+  reports.
+
   <h3 id="crash-report">Crash</h3>
 
   <dfn>Crash reports</dfn> indicate that the user was unable to continue using
@@ -1310,6 +1322,11 @@ typedef sequence&lt;Report> ReportList;
   }
   </pre>
   </div>
+
+  Note: Crash reports are always delivered to the <a>endpoint group</a> named
+  <code>default</code>; there is currently no way to override this.  If you want
+  to receive other kinds of reports, but not crash reports, make sure to use a
+  different name for the endpoint group that you choose for those reports.
 </section>
 
 <section>


### PR DESCRIPTION
Hint: it's `default`.

Issue #125