### PR TITLE
Fix typos in CSP headers

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -190,7 +190,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     And the following headers, which direct CSP and HPKP reports to that group:
 
     <pre>
-      <a>Content-Security-Policy</a>: ...; <a lt="reports directive">report-to</a>=endpoint-1
+      <a>Content-Security-Policy</a>: ...; <a lt="reports directive">report-to</a> endpoint-1
       <a>Public-Key-Pins</a>: ...; report-to=endpoint-1
     </pre>
   </div>
@@ -218,7 +218,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     endpoint:
 
     <pre>
-      <a>Content-Security-Policy</a>: ...; <a lt="reports directive">report-to</a>=csp-endpoint
+      <a>Content-Security-Policy</a>: ...; <a lt="reports directive">report-to</a> csp-endpoint
       <a>Public-Key-Pins</a>: ...; report-to=hpkp-endpoint
     </pre>
   </div>


### PR DESCRIPTION
CSP doesn't use an equal sign between field names and values.

Issue #129


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/130.html" title="Last updated on Oct 23, 2018, 3:34 PM GMT (3b4c7db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/130/6fb92dc...dcreager:3b4c7db.html" title="Last updated on Oct 23, 2018, 3:34 PM GMT (3b4c7db)">Diff</a>