### PR TITLE
Remove statement that crash reports are observable from JavaScript.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1190,7 +1190,7 @@ typedef sequence&lt;Report> ReportList;
     "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
     "body": {
       "id": "websql",
-      "anticipatedRemoval": "1/1/2020",
+      "anticipatedRemoval": "2020-01-01",
       "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
       "sourceFile": "https://example.com/index.js",
       "lineNumber": 1234,
@@ -1285,8 +1285,6 @@ typedef sequence&lt;Report> ReportList;
   optionally the reason for the crash (such as "oom").
 
   <a>Crash reports</a> have the <a>report type</a> "crash".
-
-  <a>Crash reports</a> are <a>visible to <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
     interface CrashReportBody : ReportBody {


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/134.html" title="Last updated on Nov 26, 2018, 4:38 PM GMT (32f8de5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/134/d6f77a7...paulmeyer90:32f8de5.html" title="Last updated on Nov 26, 2018, 4:38 PM GMT (32f8de5)">Diff</a>