### PR TITLE
Remove Crash IDs from crash reports.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1290,18 +1290,12 @@ typedef sequence&lt;Report> ReportList;
 
   <pre class="idl">
     interface CrashReportBody : ReportBody {
-      readonly attribute DOMString crashId;
       readonly attribute DOMString? reason;
     };
   </pre>
 
   An <a>crash report</a>'s [=report/body=], represented in JavaScript by
-  {{CrashReportBody}}, contains the following fields:
-
-    - <dfn for="CrashReportBody">crashId</dfn>: An implementation-defined unique
-      identifier (100 character maximum string). This identifier will not be
-      meaningful to developers directly, but it can potentially be supplied to
-      the browser vendor for more details.
+  {{CrashReportBody}}, contains the following field:
 
     - <dfn for="CrashReportBody">reason</dfn>: A more specific classification of
       the type of crash that occured. Currently, the only valid
@@ -1316,7 +1310,6 @@ typedef sequence&lt;Report> ReportList;
     "url": "https://example.com/",
     "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
     "body": {
-      "crashId": "30437694edfeae5b",
       "reason": "oom"
     }
   }


### PR DESCRIPTION
Because of privacy concerns, and because the process for using these IDs is currently unspecified anyways.

See #135.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/136.html" title="Last updated on Nov 26, 2018, 5:00 PM GMT (8a299c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/136/d6f77a7...paulmeyer90:8a299c2.html" title="Last updated on Nov 26, 2018, 5:00 PM GMT (8a299c2)">Diff</a>