### PR TITLE
Add the "unresponsive" reason for crash reports.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1296,10 +1296,10 @@ typedef sequence&lt;Report> ReportList;
   {{CrashReportBody}}, contains the following field:
 
     - <dfn for="CrashReportBody">reason</dfn>: A more specific classification of
-      the type of crash that occured if known, or omitted otherwise. The
+      the type of crash that occured, if known, or omitted otherwise. The
       valid <a>reason</a> strings are shown below.
 
-  <table border=1 style="padding: 20px 0px; border-collapse: collapse;">
+  <table border=1 cellpadding=5px style="border-collapse: collapse;">
     <tbody>
       <tr>
         <th><a>Reason</a></th>
@@ -1311,14 +1311,10 @@ typedef sequence&lt;Report> ReportList;
       </tr>
       <tr>
         <td>unresponsive</td>
-        <td>The page was unresponsive.</td>
+        <td>The page was killed due to being unresponsive.</td>
       </tr>
     </tbody>
   </table>
-  
-  Currently, the only valid
-      [=CrashReportBody/reason=] is "oom" (omitted otherwise), indicating an
-      out-of-memory crash.
 
   <div class="example">
   <pre>

--- a/index.src.html
+++ b/index.src.html
@@ -1296,7 +1296,27 @@ typedef sequence&lt;Report> ReportList;
   {{CrashReportBody}}, contains the following field:
 
     - <dfn for="CrashReportBody">reason</dfn>: A more specific classification of
-      the type of crash that occured. Currently, the only valid
+      the type of crash that occured if known, or omitted otherwise. The
+      valid <a>reason</a> strings are shown below.
+
+  <table border=1 style="padding: 20px 0px; border-collapse: collapse;">
+    <tbody>
+      <tr>
+        <th><a>Reason</a></th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td>oom</td>
+        <td>The page ran out of memory.</td>
+      </tr>
+      <tr>
+        <td>unresponsive</td>
+        <td>The page was unresponsive.</td>
+      </tr>
+    </tbody>
+  </table>
+  
+  Currently, the only valid
       [=CrashReportBody/reason=] is "oom" (omitted otherwise), indicating an
       out-of-memory crash.
 


### PR DESCRIPTION
This adds "unresponsive" as a possible |reason| field value in crash report bodies. This reason should be set when the page was killed due to being unresponsive. This would provide devs with an indication about faulty/misbehaving (or just too much) script on their page.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/139.html" title="Last updated on Nov 27, 2018, 7:03 PM GMT (627a817)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/139/0889dc1...paulmeyer90:627a817.html" title="Last updated on Nov 27, 2018, 7:03 PM GMT (627a817)">Diff</a>