### PR TITLE
Limit report delivery per page

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -636,6 +636,13 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   The media type used when POSTing reports to a specified endpoint is
   `application/reports+json`.
 
+  <h3 id="report-count">Report Count</h3>
+
+  Each <a>environment settings object</a> has a <dfn>report count</dfn>, which
+  is a <a spec=infra>map</a> from <a>report type</a> (string) to non-negative
+  integer. <a>report count</a> is used to track how many <a>reports</a> of
+  each <a>report type</a> have been generated in the current page.
+
   <h3 id="queue-report" algorithm>
     Queue |data| as |type| for |endpoint group| on |settings|
   </h3>
@@ -645,7 +652,14 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   optional {{URL}} (|url|), the following algorithm will create a <a>report</a>,
   and add it to <a>reporting cache</a>'s queue for future delivery.
 
-  1.  Let |report| be a new <a>report</a> object with its values initialized as
+  1.  If |settings|'s <a>report count</a> contains an entry
+      with <a spec=infra>key</a> |type|, then increment that entry. Otherwise,
+      create an entry in |settings|'s <a>report count</a>
+      with <a spec=infra>key</a> |type| and <a spec=infra>value</a> 1.
+
+  2.  If |settings|'s <a>report count</a>[|type|] is greater than 100, return.
+  
+  3.  Let |report| be a new <a>report</a> object with its values initialized as
       follows:
 
       :   [=report/body=]
@@ -661,22 +675,22 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       :   [=report/attempts=]
       ::  0
 
-  2.  If |url| was not provided by the caller, let |url| be |settings|'s
+  4.  If |url| was not provided by the caller, let |url| be |settings|'s
       <a>creation URL</a>.
 
-  3.  Set |url|'s {{URL/username}} to the empty string, and its {{URL/password}}
+  5.  Set |url|'s {{URL/username}} to the empty string, and its {{URL/password}}
       to `null`.
 
-  4.  Set |report|'s [=report/url=] to the result of executing the <a>URL
+  6.  Set |report|'s [=report/url=] to the result of executing the <a>URL
       serializer</a> on |url| with the <em>exclude fragment flag</em> set.
 
-  5.  Append |report| to the <a>reporting cache</a>.
+  7.  Append |report| to the <a>reporting cache</a>.
 
-  6.  Let |environment| be |settings|'s <a>realm execution context</a>'s
+  8.  Let |environment| be |settings|'s <a>realm execution context</a>'s
       <a spec=ecmascript>realm</a>'s <a spec=ecmascript lt=realm>ECMAScript
       global environment</a>.
 
-  7.  Execute [[#notify-observers]] with |environment| and |report|.
+  9.  Execute [[#notify-observers]] with |environment| and |report|.
 
   Note: <a>reporting observers</a> can only observe reports from the
   same <a>environment settings object</a>.

--- a/index.src.html
+++ b/index.src.html
@@ -129,6 +129,9 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     text: session; url: dfn-session
     text: success; url: dfn-success
     text: trying; url: dfn-try
+spec: netinfo; urlPrefix: https://wicg.github.io/netinfo
+  type: dfn
+    text: saveData; url: savedata-attribute
 </pre>
 <pre class="biblio">
 {
@@ -651,15 +654,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   (|endpoint group|), an <a>environment settings object</a> (|settings|), and an
   optional {{URL}} (|url|), the following algorithm will create a <a>report</a>,
   and add it to <a>reporting cache</a>'s queue for future delivery.
-
-  1.  If |settings|'s <a>report count</a> contains an entry
-      with <a spec=infra>key</a> |type|, then increment that entry. Otherwise,
-      create an entry in |settings|'s <a>report count</a>
-      with <a spec=infra>key</a> |type| and <a spec=infra>value</a> 1.
-
-  2.  If |settings|'s <a>report count</a>[|type|] is greater than 100, return.
   
-  3.  Let |report| be a new <a>report</a> object with its values initialized as
+  1.  Let |report| be a new <a>report</a> object with its values initialized as
       follows:
 
       :   [=report/body=]
@@ -675,22 +671,30 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       :   [=report/attempts=]
       ::  0
 
-  4.  If |url| was not provided by the caller, let |url| be |settings|'s
-      <a>creation URL</a>.
-
-  5.  Set |url|'s {{URL/username}} to the empty string, and its {{URL/password}}
-      to `null`.
-
-  6.  Set |report|'s [=report/url=] to the result of executing the <a>URL
-      serializer</a> on |url| with the <em>exclude fragment flag</em> set.
-
-  7.  Append |report| to the <a>reporting cache</a>.
-
-  8.  Let |environment| be |settings|'s <a>realm execution context</a>'s
+  2.  Let |environment| be |settings|'s <a>realm execution context</a>'s
       <a spec=ecmascript>realm</a>'s <a spec=ecmascript lt=realm>ECMAScript
       global environment</a>.
 
-  9.  Execute [[#notify-observers]] with |environment| and |report|.
+  3.  Execute [[#notify-observers]] with |environment| and |report|.
+
+  4.  If |settings|'s <a>report count</a> contains an entry
+      with <a spec=infra>key</a> |type|, then increment that entry. Otherwise,
+      create an entry in |settings|'s <a>report count</a>
+      with <a spec=infra>key</a> |type| and <a spec=infra>value</a> 1.
+
+  5.  If |settings|'s <a>report count</a>[|type|] is greater than 100 and the
+      current <a spec="netinfo">saveData</a> preference is true, return.
+
+  6.  If |url| was not provided by the caller, let |url| be |settings|'s
+      <a>creation URL</a>.
+
+  7.  Set |url|'s {{URL/username}} to the empty string, and its {{URL/password}}
+      to `null`.
+
+  8.  Set |report|'s [=report/url=] to the result of executing the <a>URL
+      serializer</a> on |url| with the <em>exclude fragment flag</em> set.
+
+  9.  Append |report| to the <a>reporting cache</a>.
 
   Note: <a>reporting observers</a> can only observe reports from the
   same <a>environment settings object</a>.


### PR DESCRIPTION
There is currently no limit on how many reports can be generated, which could end up using up a lot of a user's data to deliver. This patch aims to limit the number of possible reports that can be reported. The limit is enforced per report type, so that one spammy report type can't prevent reports of other types from being delivered.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/142.html" title="Last updated on Feb 3, 2021, 1:26 PM UTC (7122d3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/142/6465ac1...paulmeyer90:7122d3f.html" title="Last updated on Feb 3, 2021, 1:26 PM UTC (7122d3f)">Diff</a>