### PR TITLE
Change report buffer limit to enforce per report type

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1073,8 +1073,11 @@ typedef sequence&lt;Report> ReportList;
 
   2. Append |report| to the <a>report buffer</a> associated with |environment|.
 
-  3. If the <a>report buffer</a> now contains more than 100 reports, remove the
-     item at the beginning of the <a>report buffer</a>.
+  3. Let |type| be |report|'s <a>type</a>.
+
+  4. If the <a>report buffer</a> now contains more than 100 reports
+     with <a>type</a> equal to |type|, remove the earliest item with <a>type</a>
+     equal to |type| in the <a>report buffer</a>.
 
   <h3 id="add-report" algorithm>
     Add |report| to |observer|


### PR DESCRIPTION
This patch allows the report buffer (used for ReportingObserver's |buffereed| option) to store 100 reports per report type, rather than 100 total. This will prevent the case of one spammy report type flushing out reports of other types.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/143.html" title="Last updated on Dec 11, 2018, 3:26 PM GMT (17ca311)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/143/0889dc1...paulmeyer90:17ca311.html" title="Last updated on Dec 11, 2018, 3:26 PM GMT (17ca311)">Diff</a>