### PR TITLE
Fix destination field in report delivery

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -912,8 +912,6 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       ::  ""
       :   `destination`
       ::  "`report`"
-      :   `destination`
-      ::  ""
       :   `mode`
       ::  "`cors`"
       :   `unsafe-request` flag


### PR DESCRIPTION
It's mentioned twice; the correct value is `report`.

:tophat: @annevk


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/144.html" title="Last updated on Dec 11, 2018, 3:29 PM GMT (ba9c88b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/144/58185a4...dcreager:ba9c88b.html" title="Last updated on Dec 11, 2018, 3:29 PM GMT (ba9c88b)">Diff</a>