### PR TITLE
Use Infra's definition of JSON serialization.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -26,9 +26,6 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
   type: dfn
     text: Content-Security-Policy
     text: reports directive; url: directives-reporting
-spec: ECMA-262; urlPrefix: http://www.ecma-international.org/ecma-262/6.0/
-  type: method
-    text: JSON.stringify(); url: sec-json.stringify
 spec: FETCH; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: navigation request
@@ -919,8 +916,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       :   `credentials`
       ::  "`include`"
       :   `body`
-      ::  The string resulting from executing the {{JSON.stringify()}} algorithm
-          on |collection| [[!ECMA-262]]
+      ::  A [=/body=] whose [=body/source=] is the [=byte sequence=] resulting
+          from executing [=serialize JSON to bytes=] on |collection|.
 
   4.  <a>Queue a task</a> to <a>fetch</a> |request|.
 


### PR DESCRIPTION
This also improves the type of the object assigned to a request's body.

@annevk, the types here still mismatch since https://fetch.spec.whatwg.org/#ref-for-bodyinit-safely-extract expects the source to be a Javascript object, which a byte sequence isn't, but it seems better to fix that along the lines of https://github.com/whatwg/fetch/issues/730#issuecomment-391728692.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/reporting/pull/146.html" title="Last updated on Jan 22, 2019, 10:45 PM UTC (8a7e119)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/146/25ef462...jyasskin:8a7e119.html" title="Last updated on Jan 22, 2019, 10:45 PM UTC (8a7e119)">Diff</a>