### PR TITLE
skip-service-worker -> service-worker mode

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -903,8 +903,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       ::  `null`
       :   `window`
       ::  "`no-window`"
-      :   `skip-service-worker` flag
-      ::  Set.
+      :   `service-worker mode`
+      ::  "`none`"
       :   `initiator`
       ::  ""
       :   `destination`


### PR DESCRIPTION
This is needed to match the [fetch spec](https://fetch.spec.whatwg.org/#request-service-workers-mode).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cvazac/reporting/pull/149.html" title="Last updated on Feb 6, 2019, 8:49 PM UTC (19fe40c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/149/0f5a213...cvazac:19fe40c.html" title="Last updated on Feb 6, 2019, 8:49 PM UTC (19fe40c)">Diff</a>