### PR TITLE
Show URI Template directly for generate_test_report WebDriver command

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -120,9 +120,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
     text: current browsing context; url: dfn-current-browsing-context
     text: WebDriver error; url: dfn-error
     text: WebDriver error code; url: dfn-error-code
-    text: extension command; url: dfn-extension-commands
-    text: extension command name; url: dfn-extension-command-name
-    text: extension command prefix; url: dfn-extension-command-prefix
+    text: extension command; url: dfn-extension-command
+    text: extension command uri template; url: dfn-extension-command-uri-template
     text: invalid argument; url: dfn-invalid-argument
     text: local end; url: dfn-local-end
     text: remote end steps; url: dfn-remote-end-steps
@@ -1464,13 +1463,11 @@ typedef sequence&lt;Report> ReportList;
     <tbody>
       <tr>
         <th>HTTP Method</th>
-        <th><a lt="extension command prefix">Prefix</a></th>
-        <th><a lt="extension command name">Name</a></th>
+        <th><a lt="extension command uri template">URI Template</a></th>
       </tr>
       <tr>
         <td>`POST`</td>
-        <td>`/session/{session id}/reporting`</td>
-        <td>`generate_test_report`</td>
+        <td>`/session/{session id}/reporting/generate_test_report`</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
As requested here: https://github.com/web-platform-tests/rfcs/issues/7


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/150.html" title="Last updated on Feb 11, 2019, 6:58 PM UTC (c262bdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/150/42b21cc...paulmeyer90:c262bdd.html" title="Last updated on Feb 11, 2019, 6:58 PM UTC (c262bdd)">Diff</a>