### PR TITLE
 Make endpoint selection algorithm match DNS SRV's target selection algorithm

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -724,12 +724,12 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   8.  Let |total weight| be the sum of the {{endpoint/weight}} value of each
       |endpoint| in |endpoints|.
 
-  9.  Let |weight| be a random number ≥ 0 and &lt; |total weight|.
+  9.  Let |weight| be a random number &ge; 0 and &le; |total weight|.
 
   10. For each |endpoint| in |endpoints|:
 
-      1.  If |weight| is less than |endpoint|'s {{endpoint/weight}}, return
-          |endpoint|.
+      1.  If |weight| is less than or equal to |endpoint|'s {{endpoint/weight}},
+          return |endpoint|.
 
       2.  Subtract |endpoint|'s {{endpoint/weight}} from |weight|.
 

--- a/index.src.html
+++ b/index.src.html
@@ -734,7 +734,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       2.  Subtract |endpoint|'s {{endpoint/weight}} from |weight|.
 
   11. It should not be possible to fall through to here, since the random number
-      chosen earlier will be less than |total weight|.
+      chosen earlier will be less than or equal to |total weight|.
 
   <h3 id="send-reports" algorithm>
     Send reports


### PR DESCRIPTION
This resolves an ambiguity around what should happen when all weights are 0, as mentioned in #153.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sburnett/reporting/pull/154.html" title="Last updated on May 7, 2019, 10:11 PM UTC (cfe4816)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/154/c8c8701...sburnett:cfe4816.html" title="Last updated on May 7, 2019, 10:11 PM UTC (cfe4816)">Diff</a>