### PR TITLE
Add note about capability URLs

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1510,6 +1510,11 @@ typedef sequence&lt;Report> ReportList;
   <a>report</a>'s originator. It is still possible, however, for a feature
   to unintentionally leak such data via a report's [=report/body=]. Implementers
   SHOULD ensure that URLs contained in a report's body are similarly stripped.
+
+  Even with this information stripped, there might still be sensitive
+  information encoded in the remainder of the URL. Administrators of sites that
+  use URLs in this way SHOULD consider operating their own Reporting API
+  collectors, to prevent the reporting of such URLs to third parties.
 </section>
 
 <section>


### PR DESCRIPTION
There can still be sensitive information in URLs, even after we strip out username, password, and fragment.  This patch adds a recommendation for admins to run their own collectors if they have URLs like this.

cf #155


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/162.html" title="Last updated on Feb 3, 2021, 1:26 PM UTC (85191f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/162/25202b9...dcreager:85191f8.html" title="Last updated on Feb 3, 2021, 1:26 PM UTC (85191f8)">Diff</a>