### PR TITLE
Clean up subdomain match logic

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -52,6 +52,7 @@ spec: SECURE-CONTEXTS; urlPrefix: https://w3c.github.io/webappsec-secure-context
     text: potentially trustworthy; url: is-origin-trustworthy
 spec: URL; urlPrefix: https://url.spec.whatwg.org/
   type: dfn
+    text: domain; url: concept-domain
     text: origin of a url; url: concept-url-origin
     text: URL serializer; url: concept-url-serializer
     text: URL parser; url: concept-url-parser
@@ -436,7 +437,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
 
   The OPTIONAL <dfn for="ReportTo">`include_subdomains`</dfn> member is a
   boolean that enables this <a>endpoint group</a> for all subdomains of the
-  current <a spec="html">origin</a>'s {{URL/host}}.  If no member named
+  current <a spec="html">origin</a>'s [=origin/host=].  If no member named
   "`include_subdomains`" is present in the object, or its value is not "`true`",
   the <a>endpoint group</a> will not be enabled for subdomains.
 
@@ -769,26 +770,38 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
 
               2.  Skip to the next |report|.
 
-      4.  For each |parent origin| that is a <a>superdomain match</a>
-          for |origin| [[!RFC6797]]:
+      4.  If |origin| is a [=tuple origin=] whose [=origin/host=] is a
+          [=domain=]:
 
-          1.  Let |client| be the entry in the <a>reporting cache</a> for
-              |parent origin|.
+          1.  For each |parent domain| that is a <a>superdomain match</a>
+              for |origin|'s [=origin/host=] [[!RFC6797]], considering longer
+              domains first:
 
-          2.  If there exists an <a>endpoint group</a> (|group|) in |client|'s
-              {{client/endpoint-groups}} list whose {{endpoint group/name}} is
-              |report|'s [=report/group=] <b>and</b> whose {{endpoint
-              group/subdomains}} flag is "`include`":
+              1.  Let |parent origin| be a copy of |origin|, with its
+                  [=origin/host=] replaced with |parent domain|.
 
-              1.  Let |endpoint| be the result of executing [[#choose-endpoint]]
-                  on |group|.
+              2.  Let |client| be the entry in the <a>reporting cache</a> for
+                  |parent origin|.
 
-              2.  If |endpoint| is an <a>endpoint</a>:
+              3.  If there exists an <a>endpoint group</a> (|group|) in
+                  |client|'s {{client/endpoint-groups}} list whose {{endpoint
+                  group/name}} is |report|'s [=report/group=] <b>and</b> whose
+                  {{endpoint group/subdomains}} flag is "`include`":
 
-                  1.  Append |report| to |endpoint map|'s list of reports for
-                      |endpoint|.
+                  1.  Let |endpoint| be the result of executing
+                      [[#choose-endpoint]] on |group|.
 
-                  2.  Skip to the next |report|.
+                  2.  If |endpoint| is an <a>endpoint</a>:
+
+                      1.  Append |report| to |endpoint map|'s list of reports
+                          for |endpoint|.
+
+                      2.  Skip to the next |report|.
+
+          Note: This algorithm ensures that more specific {{endpoint
+          group/subdomains}} policies take precendence over less specific ones,
+          and that {{endpoint group/subdomains}} policies are ignored for any
+          non-[=domain=] origins (e.g., for a request to a raw IP address).
 
       5.  If we reach this step, the |report| did not match any <a>endpoint</a>
           and the user agent MAY remove |report| from the <a>reporting cache</a>


### PR DESCRIPTION
Subdomain matching applies to domain names, but we were applying the logic to origins.  Not all origins have domain names!  This cleans up the text to make it more precise.  A nice side effect is that it's now more well-defined what should happen e.g. to `include_subdomains` policies for requests to a raw IP address.

cf #156 #160 
cc @chlily1 @annevk


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/163.html" title="Last updated on Jun 26, 2019, 6:41 PM UTC (2cff3e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/163/25202b9...dcreager:2cff3e1.html" title="Last updated on Jun 26, 2019, 6:41 PM UTC (2cff3e1)">Diff</a>