### PR TITLE
Add explicit [Exposed] + dictionary default value

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -964,16 +964,19 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   <h3 id=interface-reporting-observer>Interface {{ReportingObserver}}</h3>
 
   <pre class="idl">
+[Exposed=Window]
 interface ReportBody {
 };
 
+[Exposed=Window]
 interface Report {
   readonly attribute DOMString type;
   readonly attribute DOMString url;
   readonly attribute ReportBody? body;
 };
 
-[Constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options)]
+[Exposed=Window,
+ Constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options = {})]
 interface ReportingObserver {
   void observe();
   void disconnect();
@@ -1136,6 +1139,7 @@ typedef sequence&lt;Report> ReportList;
   <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
+    [Exposed=Window]
     interface DeprecationReportBody : ReportBody {
       readonly attribute DOMString id;
       readonly attribute Date? anticipatedRemoval;
@@ -1217,6 +1221,7 @@ typedef sequence&lt;Report> ReportList;
   <code>ReportingObserver</code>s</a>.
 
   <pre class="idl">
+    [Exposed=Window]
     interface InterventionReportBody : ReportBody {
       readonly attribute DOMString id;
       readonly attribute DOMString message;
@@ -1284,6 +1289,7 @@ typedef sequence&lt;Report> ReportList;
   <a>Crash reports</a> have the <a>report type</a> "crash".
 
   <pre class="idl">
+    [Exposed=Window]
     interface CrashReportBody : ReportBody {
       readonly attribute DOMString? reason;
     };


### PR DESCRIPTION
Required after heycam/webidl#423 and heycam/webidl#750. (Found from web-platform-tests/wpt#18382)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/reporting/pull/171.html" title="Last updated on Aug 20, 2019, 2:01 PM UTC (298578c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/171/25202b9...saschanaz:298578c.html" title="Last updated on Aug 20, 2019, 2:01 PM UTC (298578c)">Diff</a>