### PR TITLE
editorial: use new IDL constructor syntax

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -974,8 +974,8 @@ interface Report {
   readonly attribute ReportBody? body;
 };
 
-[Constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options)]
 interface ReportingObserver {
+  constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options = {});
   void observe();
   void disconnect();
   ReportList takeRecords();


### PR DESCRIPTION
closes #174


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/179.html" title="Last updated on Sep 16, 2019, 3:31 AM UTC (52a1b3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/179/92404e0...52a1b3f.html" title="Last updated on Sep 16, 2019, 3:31 AM UTC (52a1b3f)">Diff</a>