### PR TITLE
Update for recent WebIDL changes

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -974,8 +974,8 @@ interface Report {
   readonly attribute ReportBody? body;
 };
 
-[Constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options)]
 interface ReportingObserver {
+  constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options = {});
   void observe();
   void disconnect();
   ReportList takeRecords();


### PR DESCRIPTION
Switches ReportingObserver to new constructor operations, and includes the mandatory default value for the optional dictionary member.

Fixes: #172, #174


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/180.html" title="Last updated on Sep 16, 2019, 8:35 AM UTC (d27d44b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/180/92404e0...d27d44b.html" title="Last updated on Sep 16, 2019, 8:35 AM UTC (d27d44b)">Diff</a>