### PR TITLE
Enqueue reports for ReportingObserver asynchronously

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1034,8 +1034,8 @@ typedef sequence&lt;Report> ReportList;
   4. Set <a>context object</a>'s {{buffered}} <a>option</a> to false.
 
   5. For each |report| in the <a>report buffer</a> associated with
-     |environment|, execute [[#add-report]] with |report| and the <a>context
-     object</a>.
+     |environment|, <a>queue a task</a> to execute [[#add-report]] with |report|
+     and the <a>context object</a>.
 
   The <dfn method for=ReportingObserver><code>disconnect()</code></dfn> method,
   when invoked, must run these steps:


### PR DESCRIPTION
Fixes: #126


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/181.html" title="Last updated on Sep 18, 2019, 12:58 AM UTC (5ca08e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/181/8473238...5ca08e3.html" title="Last updated on Sep 18, 2019, 12:58 AM UTC (5ca08e3)">Diff</a>