### PR TITLE
Allow relative URLs in Report-To configurations

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -554,7 +554,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
 
           1.  If |endpoint item| has no member named "<a
               for="ReportTo">`url`</a>", or that member's value is not a
-              string, skip to the next |endpoint item|.
+              string, or if that value is not an <a>absolute-URL string</a> or a
+              <a>path-absolute-URL string</a>, skip to the next |endpoint item|.
 
           2.  If |endpoint item| has a member named "<a
               for="ReportTo">`priority`</a>", whose value is not a non-negative
@@ -570,7 +571,8 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
               :   {{endpoint/url}}
               ::  The result of executing the <a>URL parser</a> on
                   |endpoint item|'s "<a for="ReportTo">`url`</a>" member's
-                  value.
+                  value, with <a spec="url">base URL</a> set to |response|'s <a
+                  for="response" attribute>url</a>.
               :   {{endpoint/priority}}
               ::  The value of the |endpoint item|'s "<a
                   for="ReportTo">`priority`</a>" member, if present; `1`


### PR DESCRIPTION
Fixes: #147


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/184.html" title="Last updated on Sep 23, 2019, 2:35 PM UTC (f0b0c21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/184/ce47136...f0b0c21.html" title="Last updated on Sep 23, 2019, 2:35 PM UTC (f0b0c21)">Diff</a>