### PR TITLE
Disallow credentials from cross-origin reports

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -922,7 +922,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
           from executing [=serialize JSON to bytes=] on |collection|.
 
       Note: Reports are sent with credentials set to `same-origin`. This allows
-      reporting endpoints which are same-origin with the reporting site to get
+      reporting endpoints which are same-origin with the reporting page to get
       extra context about the nature of the report: for example, to understand
       whether a given user's account is triggering errors consistently, or if a
       certain sequence of actions taken on other pages is triggering a report on

--- a/index.src.html
+++ b/index.src.html
@@ -921,6 +921,15 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       ::  A [=/body=] whose [=body/source=] is the [=byte sequence=] resulting
           from executing [=serialize JSON to bytes=] on |collection|.
 
+      Note: Reports are sent with credentials set to `same-origin`. This allows
+      reporting endpoints which are same-origin with the reporting site to get
+      extra context about the nature of the report: for example, to understand
+      whether a given user's account is triggering errors consistently, or if a
+      certain sequence of actions taken on other pages is triggering a report on
+      this page. This does not leak any new information to the reporting
+      endpoint that it could not obtain in other ways. That is not the case for
+      cross-origin reporting endpoints, so they do not receive credentials.
+
   4.  <a>Queue a task</a> to <a>fetch</a> |request|.
 
   5.  <a>Wait for a response</a> (|response|).

--- a/index.src.html
+++ b/index.src.html
@@ -916,7 +916,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
       :   `unsafe-request` flag
       ::  set
       :   `credentials`
-      ::  "`include`"
+      ::  "`same-origin`"
       :   `body`
       ::  A [=/body=] whose [=body/source=] is the [=byte sequence=] resulting
           from executing [=serialize JSON to bytes=] on |collection|.


### PR DESCRIPTION
Closes: #161


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/186.html" title="Last updated on Oct 15, 2020, 8:56 PM UTC (cb1df43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/186/ce47136...cb1df43.html" title="Last updated on Oct 15, 2020, 8:56 PM UTC (cb1df43)">Diff</a>