### PR TITLE
fix typo

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -523,7 +523,7 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
   agent will have enough contextual information to deliver reports in a timely
   manner, balanced against impacting a user's experience.
 
-  That said, a user agent SHOULD make a effort to deliver reports as soon as
+  That said, a user agent SHOULD make an effort to deliver reports as soon as
   possible after queuing, as a report's data might be significantly more useful
   in the period directly after its generation than it would be a day or a week
   later.

--- a/network-reporting.bs
+++ b/network-reporting.bs
@@ -578,7 +578,7 @@ spec: origin-policy; urlPrefix: https://wicg.github.io/origin-policy/
   information to deliver reports in a timely manner, balanced against impacting
   a user's experience.
 
-  That said, a user agent SHOULD make a effort to deliver reports as soon as
+  That said, a user agent SHOULD make an effort to deliver reports as soon as
   possible after queuing, as a report's data might be significantly more useful
   in the period directly after its generation than it would be a day or a week
   later.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140617946617728:error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s3_pkt.c:1494:SSL alert number 70
140617946617728:error:1409E0E5:SSL routines:ssl3_write_bytes:ssl handshake failure:../deps/openssl/openssl/ssl/s3_pkt.c:659:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 4, 2020, 9:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Freporting%2Fpull%2F198%2F7da9f80.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgam-phon%2Freporting%2Fpull%2F198.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/reporting%23198.)._
</details>
