### PR TITLE
Fix sample reports.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -876,7 +876,7 @@ typedef sequence&lt;Report> ReportList;
       Content-Type: application/reports+json
 
       [{
-        "type": "csp",
+        "type": "csp-violation",
         "age": 10,
         "url": "https://example.com/vulnerable-page/",
         "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
@@ -896,7 +896,7 @@ typedef sequence&lt;Report> ReportList;
           "date-time": "2014-04-06T13:00:50Z",
           "hostname": "www.example.com",
           "port": 443,
-          "effective-expiration-date": "2014-05-01T12:40:50Z"
+          "effective-expiration-date": "2014-05-01T12:40:50Z",
           "served-certificate-chain": [
             "-----BEGIN CERTIFICATE-----\n
             MIIEBDCCAuygAwIBAgIDAjppMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT\n


### PR DESCRIPTION
The sample reports section in the current editor's draft is currently incompatible with the latest editor's draft of the [CSP3 spec](https://w3c.github.io/webappsec-csp/#report-violation).

The Reporting API type of a CSP violation report should be `"csp-violation"`, not `"csp"`.

Furthermore, there was a missing comma in the sample report, causing it to be not a valid JSON.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aaronshim/reporting/pull/210.html" title="Last updated on May 8, 2020, 8:11 PM UTC (e7fb91c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/210/222a13d...aaronshim:e7fb91c.html" title="Last updated on May 8, 2020, 8:11 PM UTC (e7fb91c)">Diff</a>