### PR TITLE
Meta: make "queue a report" linkable

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -298,10 +298,10 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
     Queue |data| as |type| for |destination|
   </h3>
 
-  Given a serializable object (|data|), a string (|type|), another string
+  To <dfn export lt="queue" for="reporting">queue</dfn> a <a>report</a> given a
+  serializable object (|data|), a string (|type|), another string
   (|destination|), an optional <a>environment settings object</a>
-  (|settings|), and an optional {{URL}} (|url|), the following algorithm will
-  create a <a>report</a>, which can be queued for future delivery.
+  (|settings|), and an optional {{URL}} (|url|):
 
   1.  Let |report| be a new <a>report</a> object with its values initialized as
       follows:

--- a/index.src.html
+++ b/index.src.html
@@ -298,7 +298,7 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
     Queue |data| as |type| for |destination|
   </h3>
 
-  To <dfn export lt="queue" for="reporting">queue</dfn> a <a>report</a> given a
+  To <dfn export for="reporting">queue</dfn> a <a>report</a> given a
   serializable object (|data|), a string (|type|), another string
   (|destination|), an optional <a>environment settings object</a>
   (|settings|), and an optional {{URL}} (|url|):


### PR DESCRIPTION
Helpful for https://github.com/whatwg/fetch/pull/1030. /cc @yutakahirano.

This should make this algorithm linkable using `[=reporting/queue=]` or `<a for="reporting">queue</a>`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/211.html" title="Last updated on Jun 9, 2020, 3:53 PM UTC (5842a02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/211/67da850...5842a02.html" title="Last updated on Jun 9, 2020, 3:53 PM UTC (5842a02)">Diff</a>