### PR TITLE
Editorial: align with Fetch's structured field changes

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -128,9 +128,9 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
     "publisher": "W3C"
   },
   "STRUCTURED-HEADERS": {
-    "authors": [ "Mark Nottingham", "Poul-Henning Kamp" ],
+    "authors": [ "Mark Nottingham", "Paul-Henning Kamp" ],
     "href": "https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html",
-    "title": "Structured Headers for HTTP",
+    "title": "Structured Field Values for HTTP",
     "publisher": "IETF"
   }
 }
@@ -452,11 +452,11 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
       of |response|'s <a for="response" attribute>url</a> is not <a>potentially
       trustworthy</a>.
 
-  2.  Let |parsed header| be the result of executing [=get a structured header=]
+  2.  Let |parsed header| be the result of executing [=get a structured field value=]
       given "Reporting-Endpoints" and "dictionary" from |response|'s <a
       for="response" attribute>header list</a>.
 
-  3.  If |parsed header| is null or failure, abort these steps.
+  3.  If |parsed header| is null, abort these steps.
 
   4.  Let |endpoints| be an empty list.
 

--- a/index.src.html
+++ b/index.src.html
@@ -128,7 +128,7 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
     "publisher": "W3C"
   },
   "STRUCTURED-HEADERS": {
-    "authors": [ "Mark Nottingham", "Paul-Henning Kamp" ],
+    "authors": [ "Mark Nottingham", "Poul-Henning Kamp" ],
     "href": "https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html",
     "title": "Structured Field Values for HTTP",
     "publisher": "IETF"


### PR DESCRIPTION
See https://github.com/whatwg/fetch/pull/1056.

(Note that merging this should wait until a day after the Fetch PR is merged to ensure the revised definition is picked up.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/annevk/reporting/pull/214.html" title="Last updated on Jul 14, 2020, 9:18 AM UTC (2453e24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/214/3ea7ca3...annevk:2453e24.html" title="Last updated on Jul 14, 2020, 9:18 AM UTC (2453e24)">Diff</a>