### PR TITLE
Use Infra's 'Serialize an Infra value to JSON bytes'

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -354,12 +354,11 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
 
   To <dfn>serialize a list of |reports| to JSON</dfn>,
 
-  1.  Let |collection| be a new ECMAScript `Array` object [[!ECMA-262]].
+  1.  Let |collection| be an empty list.
 
   2.  For each |report| in |reports|:
 
-      1.  Let |data| be a new ECMAScript `Object` with the following properties
-          [[!ECMA-262]]:
+      1.  Let |data| be a map with the following key/value pairs:
 
           :   `age`
           ::  The number of milliseconds between |report|'s [=report/timestamp=]
@@ -381,8 +380,8 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
 
       3.  Append |data| to |collection|.
 
-  3. Return the [=byte sequence=] resulting from executing [=serialize JSON to
-     bytes=] on |collection|.
+  3. Return the [=byte sequence=] resulting from executing [=serialize an Infra
+     value to JSON bytes=] on |collection|.
 </section>
 
 <section>


### PR DESCRIPTION
Fixes: #224


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/227.html" title="Last updated on Feb 12, 2021, 4:10 PM UTC (9afba34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/227/0429ea5...9afba34.html" title="Last updated on Feb 12, 2021, 4:10 PM UTC (9afba34)">Diff</a>