### PR TITLE
Set report request mode to POST

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -595,6 +595,8 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
   2.  Let |request| be a new <a>request</a> with the following properties
       [[FETCH]]:
 
+      :   `method`
+      ::  "`POST`"
       :   `url`
       ::  |endpoint|'s {{endpoint/url}}
       :   `origin`
@@ -606,7 +608,7 @@ spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ie
       ::  `null`
       :   `window`
       ::  "`no-window`"
-      :   `service-worker mode`
+      :   `service-workers mode`
       ::  "`none`"
       :   `initiator`
       ::  ""


### PR DESCRIPTION
The requests should always be POSTed to endpoint servers, but this information was not explicit in the construction of the request object.

Also fixes spelling of 'service-workers mode'

Closes: #232


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/233.html" title="Last updated on Feb 25, 2021, 4:32 PM UTC (fa154a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/233/500b63d...fa154a6.html" title="Last updated on Feb 25, 2021, 4:32 PM UTC (fa154a6)">Diff</a>