### PR TITLE
URL to W3C Editor's Draft fixed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Reporting API
 This document defines a generic reporting framework which allows web developers to associate a set of named reporting endpoints with an origin. Various platform features (like Content Security Policy, Network Error Reporting, and others) will use these endpoints to deliver feature-specific reports in a consistent manner.
 
 
-* Read latest draft: https://github.com/w3c/reporting
+* Read latest draft: https://w3c.github.io/reporting/
 * Discuss on [open issues](https://github.com/w3c/reporting/issues)
 
 See also the [EXPLAINER](https://github.com/w3c/reporting/blob/master/EXPLAINER.md)


### PR DESCRIPTION
The 'Read latest draft' URL referred to the Github repository, not the Editor's Draft.