### PR TITLE
 URL to version history fixed

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -16,7 +16,7 @@ Abstract:
   feature-specific reports in a consistent manner.
 Level: 1
 Indent: 2
-Version History: https://github.com/w3c/reporting/commits/master/index.src.html
+Version History: https://github.com/w3c/reporting/commits/main/index.src.html
 Boilerplate: omit conformance, omit feedback-header
 !Participate: <a href="https://github.com/w3c/reporting/issues/new">File an issue</a> (<a href="https://github.com/w3c/reporting/issues">open issues</a>)
 Markup Shorthands: css off, markdown on


### PR DESCRIPTION
Version history URL was invalid and caused a 404. There is no 'master' branch, adjusted to 'main'.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/freddieleeman/reporting/pull/243.html" title="Last updated on Oct 27, 2021, 10:21 AM UTC (891dac2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/243/1352c61...freddieleeman:891dac2.html" title="Last updated on Oct 27, 2021, 10:21 AM UTC (891dac2)">Diff</a>