### PR TITLE
ABNF grammar fix for STRUCTURED-HEADERS

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -114,7 +114,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#
     text: trying; url: dfn-try
 spec: STRUCTURED-HEADERS; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#
   type: grammar
-    text: sh-dictionary; url: rfc.section.3.2
+    text: sf-dictionary; url: section-3.2
 </pre>
 <pre class="biblio">
 {


### PR DESCRIPTION
Since draft-ietf-httpbis-header-structure-18 the "sh-" prefix for ABNF was changed to "sf-".

https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-19#appendix-C.1


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/freddieleeman/reporting/pull/245.html" title="Last updated on Oct 27, 2021, 12:06 PM UTC (10a0100)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/245/1352c61...freddieleeman:10a0100.html" title="Last updated on Oct 27, 2021, 12:06 PM UTC (10a0100)">Diff</a>