### PR TITLE
Export "generate and queue a report" instead of "queue a report".

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -298,7 +298,7 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
     Queue |data| as |type| for |destination|
   </h3>
 
-  To <dfn>queue a report</dfn> given a
+  To <dfn>generate a report</dfn> given a
   serializable object (|data|), a string (|type|), another string
   (|destination|), an optional <a>environment settings object</a>
   (|settings|), and an optional {{URL}} (|url|):
@@ -327,14 +327,6 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
 
   4.  Set |report|'s [=report/url=] to the result of executing the <a>URL
       serializer</a> on |url| with the <em>exclude fragment flag</em> set.
-
-  5.  If |settings| is given, then
-
-      1.  Let |scope| be |settings|'s [=environment settings object/global
-          object=].
-
-      2.  If |scope| is an object implementing {{WindowOrWorkerGlobalScope}},
-          then execute [[#notify-observers]] with |scope| and |report|.
 
   6.  Return |report|.
 
@@ -494,15 +486,23 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
   <h4 id="generate-report" export algorithm>Generate report of |type| with
   |data|</h4>
 
-  When the user agent is to <dfn export>generate a report</dfn> for a <a>Document</a>
+  When the user agent is to <dfn export>generate and queue a report</dfn> for a <a>Document</a>
   or {{WorkerGlobalScope}} object (|context|), given a string (|type|), another
   string (|destination|), and a serializable object (|data|), it must run the
   following steps:
 
   1.  Let |settings| be |context|'s [=relevant settings object=].
 
-  2.  Let |report| be the result of running [=queue a report=] with |data|,
+  2.  Let |report| be the result of running [=generate a report=] with |data|,
       |type|, |destination| and |settings|.
+
+  1.  If |settings| is given, then
+
+      1.  Let |scope| be |settings|'s [=environment settings object/global
+          object=].
+
+      1.  If |scope| is an object implementing {{WindowOrWorkerGlobalScope}},
+          then execute [[#notify-observers]] with |scope| and |report|.
 
   3. Append |report| to |context|'s [=reports=].
 
@@ -1003,7 +1003,7 @@ typedef sequence&lt;Report> ReportList;
   9. Let |settings| be the <a>environment settings object</a> of the
      <a>current browsing context</a>'s <a>active document</a>.
 
-  10. Execute [=queue a report=] with |body|, "test", |group|, and |settings|.
+  10. Execute [=generate and queue a report=] with |body|, "test", |group|, and |settings|.
 
   11. Return <a>success</a> with data null.
 </section>

--- a/index.src.html
+++ b/index.src.html
@@ -298,7 +298,7 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
     Queue |data| as |type| for |destination|
   </h3>
 
-  To <dfn export for="reporting">queue</dfn> a <a>report</a> given a
+  To <dfn>queue a report</dfn> given a
   serializable object (|data|), a string (|type|), another string
   (|destination|), an optional <a>environment settings object</a>
   (|settings|), and an optional {{URL}} (|url|):
@@ -494,14 +494,14 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
   <h4 id="generate-report" export algorithm>Generate report of |type| with
   |data|</h4>
 
-  When the user agent is to <dfn>generate a report</dfn> for a <a>Document</a>
+  When the user agent is to <dfn export>generate a report</dfn> for a <a>Document</a>
   or {{WorkerGlobalScope}} object (|context|), given a string (|type|), another
   string (|destination|), and a serializable object (|data|), it must run the
   following steps:
 
   1.  Let |settings| be |context|'s [=relevant settings object=].
 
-  2.  Let |report| be the result of running [[#queue-report]] with |data|,
+  2.  Let |report| be the result of running [=queue a report=] with |data|,
       |type|, |destination| and |settings|.
 
   3. Append |report| to |context|'s [=reports=].
@@ -948,7 +948,7 @@ typedef sequence&lt;Report> ReportList;
 
   <h3 id="generate-test-report-command">Generate Test Report</h3>
 
-  The <dfn>Generate Test Report</dfn> <a>extension command</a> simulates the
+  The <dfn export>Generate Test Report</dfn> <a>extension command</a> simulates the
   generation of a <a>report</a> for the purposes of testing. This report will be
   observed by any <a>registered</a> <a>reporting observers</a>.
 
@@ -1003,7 +1003,7 @@ typedef sequence&lt;Report> ReportList;
   9. Let |settings| be the <a>environment settings object</a> of the
      <a>current browsing context</a>'s <a>active document</a>.
 
-  10. Execute [[#queue-report]] with |body|, "test", |group|, and |settings|.
+  10. Execute [=queue a report=] with |body|, "test", |group|, and |settings|.
 
   11. Return <a>success</a> with data null.
 </section>


### PR DESCRIPTION
Please check that callers should actually be calling "generate a report" instead of "queue a report". If this is correct, we need to fix up https://fetch.spec.whatwg.org/#ref-for-reporting-queue and https://w3c.github.io/webappsec-permissions-policy/#ref-for-reporting-queue right after merging this. (found with https://dontcallmedom.github.io/webdex/q.html#queue%40%40reporting%40dfn)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#queue-report, #generate-report
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/reporting/pull/253.html" title="Last updated on Sep 15, 2022, 10:59 PM UTC (f20779a)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/reporting/pull/253.html#queue-report" title="#queue-report">#queue-report</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/reporting/pull/253.html#generate-report" title="#generate-report">#generate-report</a>) | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/253/60d1551...jyasskin:f20779a.html" title="Last updated on Sep 15, 2022, 10:59 PM UTC (f20779a)">Diff</a>