### PR TITLE
Fix spec-prod action destination

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: index.src.html
+          DESTINATION: index.html
           TOOLCHAIN: bikeshed
           BUILD_FAIL_ON: warning
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}


### PR DESCRIPTION
The previous fix caused the main spec to be rendered as `index.src.html` in the gh-pages branch, rather than as `index.html`. This corrects that with a `DESTINATION` directive.