### PR TITLE
Change Report and ReportBody interfaces to dicts.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -679,17 +679,13 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
   <h3 id=interface-reporting-observer>Interface {{ReportingObserver}}</h3>
 
   <pre class="idl">
-[Exposed=(Window,Worker)]
-interface ReportBody {
-  [Default] object toJSON();
+dictionary ReportBody {
 };
 
-[Exposed=(Window,Worker)]
-interface Report {
-  [Default] object toJSON();
-  readonly attribute DOMString type;
-  readonly attribute DOMString url;
-  readonly attribute ReportBody? body;
+dictionary Report {
+  DOMString type;
+  DOMString url;
+  ReportBody? body;
 };
 
 [Exposed=(Window,Worker)]
@@ -710,11 +706,11 @@ dictionary ReportingObserverOptions {
 typedef sequence&lt;Report> ReportList;
   </pre>
 
-  A <dfn id=dom-report interface>Report</dfn> is the application exposed
-  representation of a <a>report</a>. <dfn attribute for="Report">type</dfn>
-  returns [=report/type=], <dfn attribute for="Report">url</dfn> returns
-  [=report/url=], and <dfn attribute for="Report">body</dfn> returns
-  [=report/body=].
+  A <dfn id=dom-report dictionary>Report</dfn> is the application-exposed
+  representation of a <a>report</a>.
+
+  <dfn id="reportbody" dictionary>ReportBody</dfn> is an abstract dictionary
+  type from which specific report types should inherit.
 
   Each {{ReportingObserver}} object has these associated concepts:
     - A <dfn for=ReportingObserver>callback</dfn> function set on creation.


### PR DESCRIPTION
This change removes any suggestion that the two interface names (and the names of those interfaces which inherit from `ReportBody`) should be exposed on the global object. `ReportBody` is purely abstract, and exists so that it can be used as the type of the `body` member of `Report`, while still allowing other specifications to define new subtypes for their own report types.

Closes: #216


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/pull/258.html" title="Last updated on Dec 5, 2022, 12:32 PM UTC (e894337)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/258/9ef0608...e894337.html" title="Last updated on Dec 5, 2022, 12:32 PM UTC (e894337)">Diff</a>