### PR TITLE
Fix a link to a Background Sync issue

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1045,7 +1045,7 @@ typedef sequence&lt;Report> ReportList;
   network through other means in any case, even after the document is closed,
   through mechanisms such as `navigator.sendBeacon`.
 
-  ISSUE(w3c/BackgroundSync#107): Consider mitigations. For example, we could
+  ISSUE(WICG/background-sync#107): Consider mitigations. For example, we could
   drop reports if we change from one network to another.
 
   <h3 id="fingerprinting-clock-skew">Clock Skew</h3>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#network-leakage
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/reporting/pull/264.html#network-leakage" title="Last updated on May 11, 2023, 8:27 PM UTC (160c399)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/264/9ef0608...jyasskin:160c399.html" title="Last updated on May 11, 2023, 8:27 PM UTC (160c399)">Diff</a>