### PR TITLE
Export dfn of 'visible to ReportingObserver'

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -241,7 +241,7 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
   of data that is contained in the [=report/body=] of a <a>report</a>.
 
   When a <a>report type</a> is defined (in this spec or others), it can be
-  specified to be <dfn>visible to <code>ReportingObserver</code>s</dfn>, meaning
+  specified to be <dfn export>visible to <code>ReportingObserver</code>s</dfn>, meaning
   that <a>reports</a> of that type can be observed by a <a>reporting
   observer</a>. By default, <a>report types</a> are not <a>visible to
   <code>ReportingObserver</code>s</a>.


### PR DESCRIPTION
Since it is marked as being useful for other specs (and is indeed being used in https://w3c.github.io/network-error-logging/ )


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/reporting/pull/266.html" title="Last updated on Nov 10, 2023, 9:23 AM UTC (2eb7d75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/reporting/266/1d8233d...dontcallmedom:2eb7d75.html" title="Last updated on Nov 10, 2023, 9:23 AM UTC (2eb7d75)">Diff</a>