### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -833,10 +833,9 @@ typedef sequence&lt;Report> ReportList;
 
      3. Empty |observer|'s <a>report queue</a>
 
-     4. <a spec=webidl>Invoke</a> |observer|'s <a>callback</a> with a list of
-        arguments consisting of |reports| and |observer|, and |observer| as the
-        <a>callback this value</a>.  If this throws an exception, <a>report the
-        exception</a>.
+     4. <a spec=webidl>Invoke</a> |observer|'s <a>callback</a> with
+        « |reports|, |observer| » and "`report`", and with |observer| as the
+        <a>callback this value</a>.
 </section>
 
 <section>


### PR DESCRIPTION
This algorithm can now handle the need to report an exception thrown by the callback. Some small tweaks are made for consistency with other specifications.

Part of whatwg/webidl#1425.