### PR TITLE
Export named parameters for "generate and queue a report"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -486,7 +486,7 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
   <h4 id="generate-report" export algorithm>Generate report of |type| with
   |data|</h4>
 
-  When the user agent is to <dfn export>generate and queue a report</dfn> for a <a>Document</a>
+  When the user agent is to <dfn export>generate and queue a report</dfn> for a {{Document}}
   or {{WorkerGlobalScope}} object (<dfn export for="generate and queue a report">|context|</dfn>),
   given a string (<dfn export for="generate and queue a report">|type|</dfn>),
   a string (<dfn export for="generate and queue a report">|destination|</dfn>), and

--- a/index.bs
+++ b/index.bs
@@ -487,9 +487,11 @@ spec: STRUCTURED-FIELDS; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html#
   |data|</h4>
 
   When the user agent is to <dfn export>generate and queue a report</dfn> for a <a>Document</a>
-  or {{WorkerGlobalScope}} object (|context|), given a string (|type|), another
-  string (|destination|), and a serializable object (|data|), it must run the
-  following steps:
+  or {{WorkerGlobalScope}} object (<dfn export for="generate and queue a report">|context|</dfn>),
+  given a string (<dfn export for="generate and queue a report">|type|</dfn>),
+  a string (<dfn export for="generate and queue a report">|destination|</dfn>), and
+  a serializable object (<dfn export for="generate and queue a report">|data|</dfn>),
+  it must run the following steps:
 
   1.  Let |settings| be |context|'s [=relevant settings object=].
 

--- a/network-reporting.bs
+++ b/network-reporting.bs
@@ -555,7 +555,7 @@ spec: origin-policy; urlPrefix: https://wicg.github.io/origin-policy/
 
   When a user agent is to <dfn export>generate a network report</dfn>, given a
   string (|type|), another string (|endpoint group|), a serializable object
-  (|data|), and an optional <a>Document</a> (|document|), it must run the
+  (|data|), and an optional {{Document}} (|document|), it must run the
   following steps:
 
   1.  If |document| is given, then


### PR DESCRIPTION
The lack of named parameters export came up as part of the review of https://github.com/w3c/webappsec-subresource-integrity/pull/133
This PR adds them.

It also fixes linking errors around `Document` for both reporting and network reporting.